### PR TITLE
install fog to use S3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,5 +81,6 @@ gem 'active_hash'
 gem 'ancestry'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'fog-aws'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     diff-lcs (1.4.4)
     erubi (1.9.0)
     erubis (2.7.0)
+    excon (0.76.0)
     factory_bot (6.0.2)
       activesupport (>= 5.0.0)
     factory_bot_rails (6.0.0)
@@ -124,8 +125,25 @@ GEM
     faker (2.12.0)
       i18n (>= 1.6, < 2)
     ffi (1.13.1)
+    fog-aws (3.6.6)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.0)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-sass (5.13.0)
       sassc (>= 1.11)
+    formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     haml (5.1.2)
@@ -147,6 +165,7 @@ GEM
     image_processing (1.11.0)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    ipaddress (0.8.3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -166,12 +185,16 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     msgpack (1.3.3)
+    multi_json (1.15.0)
     mysql2 (0.5.3)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
@@ -343,6 +366,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  fog-aws
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -5,7 +5,7 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Choose what kind of storage to use for this uploader:
   storage :file
-  # storage :fog
+  storage :fog
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,17 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+CarrierWave.configure do |config|
+  config.storage = :fog
+  config.fog_provider = 'fog/aws'
+  config.fog_credentials = {
+    provider: 'AWS',
+    aws_access_key_id: ENV["AWS_ACCESS_KEY_ID"],
+    aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
+    region: 'ap-northeast-1'
+  }
+
+  config.fog_directory  = 'fleamarket79g'
+  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/fleamarket79g'
+end


### PR DESCRIPTION
## what
S3の導入

## why
イメージファイルをAWSのS3に導入することで、イメージファイルの容量が溢れないようにする